### PR TITLE
Fix typeahead bestbet template

### DIFF
--- a/scripts/quicksearch-typeahead.js
+++ b/scripts/quicksearch-typeahead.js
@@ -59,7 +59,7 @@ var bestbets_template = Handlebars.compile([
         '<div class="row">',
           '<div class="small-12 columns bestbet-container">',
             '<span class="suggestion-title">{{value}}</span>',
-            '{{#description}}<p class="bestbet-description">{{description}}</p>{{/description}}',
+            '{{#if description}}<p class="bestbet-description">{{description}}</p>{{/if}}',
           '</div>',
         '</div>',
 ].join(''));


### PR DESCRIPTION
Forgot to update this syntax when changing from Hogan.js templates to Handlebars.js
